### PR TITLE
pra-28-экран-или-страница-начала-игры

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,4 +24,5 @@ module.exports = {
     'react-hooks/exhaustive-deps': "error",
     'import/no-default-export': 2
   },
+  "ignorePatterns": ["**/*.test.*", "**/*.config.*"]
 };

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import { BackgroundLayout } from './layouts/BackgroundLayout';
 import { useAppDispatch, useAppSelector } from './hooks/redux';
 import { fetchAuth } from './store/auth/AuthActions';

--- a/packages/client/src/components/ProgressBar/ProgressBar.module.scss
+++ b/packages/client/src/components/ProgressBar/ProgressBar.module.scss
@@ -1,0 +1,15 @@
+@import 'src/index.module.scss';
+
+.container {
+  height: 30px;
+  width: 100%;
+  background-color: $progress_bar_bg_color;
+  border: 4px solid $progress_bar_border_color;
+}
+
+.filler {
+  height: 100%;
+  border-radius: inherit;
+  text-align: right;
+  transition: width 1s ease-in-out;
+}

--- a/packages/client/src/components/ProgressBar/ProgressBar.tsx
+++ b/packages/client/src/components/ProgressBar/ProgressBar.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styles from './ProgressBar.module.scss';
+
+type BarProps = {
+  bgcolor: string;
+  completed: number;
+};
+
+export const ProgressBar = ({ bgcolor, completed }: BarProps) => {
+  return (
+    <div className={styles.container}>
+      <div
+        className={styles.filler}
+        style={
+          {
+            backgroundColor: `${bgcolor}`,
+            width: `${completed}%`,
+          } as React.CSSProperties
+        }></div>
+    </div>
+  );
+};

--- a/packages/client/src/components/ProgressBar/hooks/useProgress.tsx
+++ b/packages/client/src/components/ProgressBar/hooks/useProgress.tsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+
+export const useProgress = () => {
+  const [running, setRunning] = useState(true);
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    let id: ReturnType<typeof setInterval> = 0;
+
+    if (running) {
+      id = setInterval(() => {
+        setProgress(prev => prev + 5);
+      }, 500);
+    }
+    return () => {
+      clearInterval(id);
+    };
+  }, [running]);
+
+  useEffect(() => {
+    if (progress === 100) {
+      setRunning(false);
+    }
+  }, [progress]);
+
+  return [progress];
+};

--- a/packages/client/src/components/ProgressBar/index.tsx
+++ b/packages/client/src/components/ProgressBar/index.tsx
@@ -1,0 +1,1 @@
+export { ProgressBar } from './ProgressBar';

--- a/packages/client/src/components/Routing/Routing.tsx
+++ b/packages/client/src/components/Routing/Routing.tsx
@@ -6,6 +6,7 @@ import {
   LoginPage,
   RegistrationPage,
   Leaderboard,
+  GameLoadingPage,
 } from '../../pages';
 import { ProtectedRoute } from '../ProtectedRoute';
 import { BackgroundLayout } from '../../layouts/BackgroundLayout';
@@ -62,6 +63,7 @@ export const Routing = () => {
           </BackgroundLayout>
         }
       />
+      <Route path="/loading" element={<GameLoadingPage />} />
       <Route path="/500" element={<ErrorPage500 />} />
       <Route path="*" element={<ErrorPage404 />} />
     </Routes>

--- a/packages/client/src/components/Spinner/Spinner.tsx
+++ b/packages/client/src/components/Spinner/Spinner.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import styles from './spinner.module.scss';
+
+export const Spinner = () => {
+  return (
+    <div className={styles.container}>
+      <div className={styles.ispinner_blade}></div>
+      <div className={styles.ispinner}>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+        <div className={styles.ispinner_blade}></div>
+      </div>
+    </div>
+  );
+};

--- a/packages/client/src/components/Spinner/index.tsx
+++ b/packages/client/src/components/Spinner/index.tsx
@@ -1,0 +1,1 @@
+export { Spinner } from './Spinner';

--- a/packages/client/src/components/Spinner/spinner.module.scss
+++ b/packages/client/src/components/Spinner/spinner.module.scss
@@ -1,0 +1,60 @@
+.ispinner {
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+.ispinner .ispinner_blade {
+  position: absolute;
+  top: 13px;
+  left: 8.5px;
+  width: 8px;
+  height: 16px;
+  background-color: #8e8e93;
+  border-radius: 1.25px;
+  animation: iSpinnerBlade 1s linear infinite;
+  will-change: opacity;
+}
+.ispinner .ispinner_blade:nth-child(1) {
+  transform: rotate(45deg) translateY(20px);
+  animation-delay: -1.625s;
+}
+.ispinner .ispinner_blade:nth-child(2) {
+  transform: rotate(90deg) translateY(20px);
+  animation-delay: -1.5s;
+}
+.ispinner .ispinner_blade:nth-child(3) {
+  transform: rotate(135deg) translateY(20px);
+  animation-delay: -1.375s;
+}
+.ispinner .ispinner_blade:nth-child(4) {
+  transform: rotate(180deg) translateY(20px);
+  animation-delay: -1.25s;
+}
+.ispinner .ispinner_blade:nth-child(5) {
+  transform: rotate(225deg) translateY(20px);
+  animation-delay: -1.125s;
+}
+.ispinner .ispinner_blade:nth-child(6) {
+  transform: rotate(270deg) translateY(20px);
+  animation-delay: -1s;
+}
+.ispinner .ispinner_blade:nth-child(7) {
+  transform: rotate(315deg) translateY(20px);
+  animation-delay: -0.875s;
+}
+.ispinner .ispinner_blade:nth-child(8) {
+  transform: rotate(360deg) translateY(20px);
+  animation-delay: -0.75s;
+}
+
+@keyframes iSpinnerBlade {
+  0% {
+    opacity: 0.85;
+  }
+  50% {
+    opacity: 0.25;
+  }
+  100% {
+    opacity: 0.25;
+  }
+}

--- a/packages/client/src/hooks/useMountEffect.ts
+++ b/packages/client/src/hooks/useMountEffect.ts
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
 
 export const useMountEffect = (effectCallback: () => (() => void) | void) => {
-  useEffect(effectCallback, []);
+  useEffect(effectCallback);
 };

--- a/packages/client/src/index.module.scss
+++ b/packages/client/src/index.module.scss
@@ -2,3 +2,7 @@
 @import './styles/mixins.scss';
 @import './styles/variables.scss';
 @import './styles/reset.scss';
+
+body {
+  position: relative;
+}

--- a/packages/client/src/pages/GameLoadingPage/GameLoadingPage.module.scss
+++ b/packages/client/src/pages/GameLoadingPage/GameLoadingPage.module.scss
@@ -1,0 +1,27 @@
+@import 'src/index.module.scss';
+
+.game_loading_root {
+  display: flex;
+  flex-direction: column;
+  background-color: $bg-color-loading;
+  height: 100vh;
+  width: 100%;
+  justify-content: center;
+  align-items: center;
+}
+
+.game_loading_title {
+  @include fontTitle(normal, 400, 100px, 100px);
+  color: $main_logo_text_color;
+}
+
+.bar_container {
+  width: 80%;
+  margin-top: 90px;
+}
+
+.percent {
+  @include fontText(normal, 400, 24px, 40px);
+  color: $text-primary;
+  margin-top: 30px;
+}

--- a/packages/client/src/pages/GameLoadingPage/GameLoadingPage.tsx
+++ b/packages/client/src/pages/GameLoadingPage/GameLoadingPage.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styles from './GameLoadingPage.module.scss';
+import { Spinner } from 'src/components/Spinner';
+import { ProgressBar } from 'src/components/ProgressBar';
+import { useProgress } from 'src/components/ProgressBar/hooks/useProgress';
+
+export const GameLoadingPage: React.FC = (): JSX.Element => {
+  const [progress] = useProgress();
+
+  return (
+    <div className={styles.game_loading_root}>
+      <h1 className={styles.game_loading_title}>
+        Huggy Wuggy
+        <br />& Kissy Missy
+      </h1>
+      <Spinner />
+      <div className={styles.bar_container}>
+        <ProgressBar completed={progress} bgcolor={'#FFCC00'} />
+      </div>
+      <div className={styles.percent}>{progress} %</div>
+    </div>
+  );
+};

--- a/packages/client/src/pages/GameLoadingPage/index.ts
+++ b/packages/client/src/pages/GameLoadingPage/index.ts
@@ -1,0 +1,1 @@
+export { GameLoadingPage } from './GameLoadingPage';

--- a/packages/client/src/pages/LoginPage/LoginPage.tsx
+++ b/packages/client/src/pages/LoginPage/LoginPage.tsx
@@ -13,7 +13,7 @@ export const LoginPage: React.FC = (): JSX.Element => {
     if (auth) {
       navigate('/');
     }
-  }, [auth]);
+  }, [auth, navigate]);
 
   return (
     <div className={stylesForm.form_root}>

--- a/packages/client/src/pages/RegistrationPage/RegistrationPage.tsx
+++ b/packages/client/src/pages/RegistrationPage/RegistrationPage.tsx
@@ -12,7 +12,7 @@ export const RegistrationPage: React.FC = (): JSX.Element => {
     if (auth) {
       navigate('/');
     }
-  }, [auth]);
+  }, [auth, navigate]);
 
   return (
     <div className={stylesForm.form_root}>

--- a/packages/client/src/pages/index.ts
+++ b/packages/client/src/pages/index.ts
@@ -1,9 +1,17 @@
-import { Forum } from "./Forum";
-import { LoginPage } from "./LoginPage";
-import { RegistrationPage } from "./RegistrationPage";
-import { ErrorPage404 } from "./404";
-import { ErrorPage500 } from "./500";
-import { Leaderboard } from "./Leaderboard";
+import { Forum } from './Forum';
+import { LoginPage } from './LoginPage';
+import { RegistrationPage } from './RegistrationPage';
+import { ErrorPage404 } from './404';
+import { ErrorPage500 } from './500';
+import { Leaderboard } from './Leaderboard';
+import { GameLoadingPage } from './GameLoadingPage';
 
-
-export { Forum, LoginPage, RegistrationPage, ErrorPage404, ErrorPage500, Leaderboard }; 
+export {
+  Forum,
+  LoginPage,
+  RegistrationPage,
+  ErrorPage404,
+  ErrorPage500,
+  Leaderboard,
+  GameLoadingPage,
+};

--- a/packages/client/src/store/utils.ts
+++ b/packages/client/src/store/utils.ts
@@ -1,6 +1,6 @@
 const baseUrl = 'https://ya-praktikum.tech/api/v2/auth';
 
-export const fetchApi = (path: string, options: RequestInit): Promise<any> => {
+export const fetchApi = <T>(path: string, options: RequestInit): Promise<T> => {
   return fetch(`${baseUrl}${path}`, {
     ...options,
     credentials: 'include',

--- a/packages/client/src/styles/variables.scss
+++ b/packages/client/src/styles/variables.scss
@@ -1,5 +1,6 @@
 // colors
 $bg-color-main: #222739;
+$bg-color-loading: #111318;
 $bg-color-secondary: #37446e;
 $color-card: rgba(24, 27, 34, 0.7);
 $text-primary: #ffffff;
@@ -8,6 +9,8 @@ $main_logo_text_color: rgb(251, 55, 255);
 $main_input_text_color: rgb(255, 255, 255);
 $main_input_bg_color: rgb(55, 68, 110);
 $main_block_bg_color: rgba(24, 27, 34, 0.49);
+$progress_bar_bg_color: #222739;
+$progress_bar_border_color: black;
 
 $main_input_border_error: red;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3637,7 +3637,7 @@ eslint-module-utils@^2.7.3:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-import@^2.26.0:
+eslint-plugin-import@2.26.0:
   version "2.26.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz#f812dc47be4f2b72b478a021605a59fc6fe8b88b"
   integrity sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==
@@ -3656,7 +3656,7 @@ eslint-plugin-import@^2.26.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
-eslint-plugin-react-hooks@^4.6.0:
+eslint-plugin-react-hooks@4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==


### PR DESCRIPTION
Добавила экран для загрузки игры.

Для целей тестирования он открыватеся по роуту /loading Когда интегрируем с игрой, надо будет этот роут убрать.
Сейчас используется Interval, для того чтобы progress bar живой был. Если в игре будет какой-то вариант прикрутить к реальном процессу, сделаем, пропсы для этого есть.

Если у кого есть идеи, как использовать scss variables прям внутри компонента, сообщите. я не нашла рабочего способа, без использования каких-то костылей.

Также поправлены следующие баги верстки:
- при растягивании затенение бэкграунда теперь тоже растягивается (в body добавлено position:relative).
- исправлена опечатка в variables (и в компоненте)

![Screenshot at Nov 01 14-16-31](https://user-images.githubusercontent.com/4964091/199244352-15dd0ada-a7a9-46f1-8595-fc318bc37a29.png)
