### PR TITLE
feat: добавила очистку данных пользователя при logout и запрос данных…

### DIFF
--- a/packages/client/src/pages/SettingsPage/components/SettingsChangeData/SettingsChangeData.tsx
+++ b/packages/client/src/pages/SettingsPage/components/SettingsChangeData/SettingsChangeData.tsx
@@ -14,7 +14,7 @@ import { useNavigator } from 'src/hooks/useNavigator';
 import { IUser } from 'src/modules/IUser';
 
 export const SettingsChangeData = () => {
-  const user = useAppSelector(state => state.auth.user!);
+  const user = useAppSelector(state => state.auth.user as IUser);
 
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
@@ -26,7 +26,7 @@ export const SettingsChangeData = () => {
     dispatch(fetchChangeUser(values))
       .unwrap()
       .catch()
-      .then(res => {
+      .then(() => {
         goBackHandle();
       });
   };

--- a/packages/client/src/pages/SettingsPage/components/SettingsChangePassword/SettingsChangePassword.tsx
+++ b/packages/client/src/pages/SettingsPage/components/SettingsChangePassword/SettingsChangePassword.tsx
@@ -27,7 +27,7 @@ export const SettingsChangePassword = () => {
     dispatch(fetchChangePassword(values))
       .unwrap()
       .catch()
-      .then(res => {
+      .then(() => {
         goBackHandle();
       });
   };

--- a/packages/client/src/pages/SettingsPage/components/SettingsUserInfo/SettingsUserInfo.tsx
+++ b/packages/client/src/pages/SettingsPage/components/SettingsUserInfo/SettingsUserInfo.tsx
@@ -1,9 +1,10 @@
 import { useAppSelector } from 'src/hooks/redux';
+import { IUser } from 'src/modules/IUser';
 
 import stylesForm from 'src/components/Form/Form.module.scss';
 
 export const SettingsUserInfo = () => {
-  const user = useAppSelector(state => state.auth.user!);
+  const user = useAppSelector(state => state.auth.user as IUser);
 
   return (
     <div className={stylesForm.form_center}>

--- a/packages/client/src/store/auth/AuthActions.ts
+++ b/packages/client/src/store/auth/AuthActions.ts
@@ -14,8 +14,8 @@ const defaultHeaders = {
 export const fetchAuth = createAsyncThunk(
   'auth/fetchAuth',
   async (_, thunkApi) => {
-    try { 
-      return await fetchApi<IUser>('/auth/user', {});  
+    try {
+      return await fetchApi<IUser>('/auth/user', {});
     } catch (error) {
       return thunkApi.rejectWithValue('Ошибка авторизации');
     }
@@ -31,6 +31,8 @@ export const fetchSignin = createAsyncThunk(
         headers: defaultHeaders,
         body: JSON.stringify(data),
       });
+
+      thunkApi.dispatch(fetchAuth());
 
       return res;
     } catch (error) {
@@ -49,6 +51,7 @@ export const fetchSignup = createAsyncThunk(
         headers: defaultHeaders,
         body: JSON.stringify(data),
       });
+      thunkApi.dispatch(fetchAuth());
 
       return res;
     } catch (error) {

--- a/packages/client/src/store/auth/AuthSlice.ts
+++ b/packages/client/src/store/auth/AuthSlice.ts
@@ -37,7 +37,7 @@ export const authSlice = createSlice({
         state.user = action.payload;
         state.loading = false;
       }
-    ); 
+    );
     buider.addCase(fetchAuth.rejected, state => {
       state.checkAuth = true;
       state.auth = false;
@@ -79,6 +79,7 @@ export const authSlice = createSlice({
       state.loading = false;
       state.checkAuth = true;
       state.auth = false;
+      state.user = null;
     });
     buider.addCase(fetchLogout.rejected, state => {
       state.loading = false;


### PR DESCRIPTION
### Какую задачу решаем
[Добавить в logout очистку данных пользователя + запрос данных при авторизации/регистрации](https://linear.app/teamproject/issue/PRA-100/dobavit-v-logout-ochistku-dannyh-polzovatelya-zapros-dannyh-pri)

Описание бага: 
1. при logout не очищались данные пользователя
2. если сделать logout и авторизоваться или зарегистрироваться другим пользователем, показывались данные старого пользователя т к после signin signup не вызывался запрос данных нового пользователя

Как проверить исправление бага: 
(делать без перезагрузке страницы)
- зайти 1 пользователем, зайти в профиль (будут показаны данные пользователя 1)
- сделать logout (в redux tools можно увидеть, что данные очистились)
- авторизоваться новым пользователем 2 или сделать регистрацию (после успешной регистрации/авторизации отправляется 2 запрос на получение данных пользователя 2)
- зайти в профиль, в нем данные пользователя 2 (раньше были данные пользователя 1)

Дополнительно исправила замечания lint